### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implements a service for Nexmo messaging based on
 
 Include the artistan nexmo package as a dependency in your `composer.json` [Packagist](https://packagist.org/packages/artistan/nexmo):
 
-    "artistan/nexmo": "0.1.*"
+    "artistan/nexmo": "0.2.*"
 
 ### Installation
 


### PR DESCRIPTION
Inform users to require "artistan/nexmo": "0.2._" instead of
"artistan/nexmo": "0.1._"
